### PR TITLE
Ignore fsGetSearchListener

### DIFF
--- a/src/raven-ignore.js
+++ b/src/raven-ignore.js
@@ -23,7 +23,8 @@ RenuoSentryList['ignoreErrors'] = [
   'conduitPage',
   // Generic error code from errors outside the security sandbox
   // You can delete this if using raven.js > 1.0, which ignores these automatically.
-  'Script error.'
+  'Script error.',
+  'fsGetSearchListener(...) is not a function'
 ];
 
 RenuoSentryList['ignoreUrls'] = [


### PR DESCRIPTION
This is caused by https://trackjs.com/, which is most likely in a browser extension.