### PR TITLE
ignore cloudflare and IE8

### DIFF
--- a/src/raven-ignore.js
+++ b/src/raven-ignore.js
@@ -45,3 +45,7 @@ RenuoSentryList['ignoreUrls'] = [
   /webappstoolbarba\.texthelp\.com\//i,
   /metrics\.itunes\.apple\.com\.edgesuite\.net\//i
 ];
+
+RenuoSentryList['shouldSendCallback'] = function(data){
+  return !/^(.*CloudFlare-AlwaysOnline.*|.+MSIE 8\.0;.+)$/.test(window.navigator.userAgent);
+};


### PR DESCRIPTION
This PR ignores errors triggered by cloudflare and IE8.0 which we see, sometimes, on sentry.
Smoke-tested!
E.G.
* https://sentry.io/renuo/mtextur-master/issues/843544765/?query=is%3Aunresolved